### PR TITLE
Add loop support

### DIFF
--- a/migrate.go
+++ b/migrate.go
@@ -116,6 +116,8 @@ func (b byId) Len() int           { return len(b) }
 func (b byId) Swap(i, j int)      { b[i], b[j] = b[j], b[i] }
 func (b byId) Less(i, j int) bool { return b[i].Less(b[j]) }
 
+// MigrationRecord stores each migration Id & Applied timestamp
+// TODO: Change to Flyway compatible table structure if compatibility selected
 type MigrationRecord struct {
 	Id        string    `db:"id"`
 	AppliedAt time.Time `db:"applied_at"`
@@ -311,6 +313,9 @@ func ExecMax(db *sql.DB, dialect string, m MigrationSource, dir MigrationDirecti
 			}
 		}
 
+		// TODO: Add support for looping case
+		// TODO: Support the migrationStatement type
+		// TODO: Add validation check for looping case with conditional
 		for _, stmt := range migration.Queries {
 			if _, err := executor.Exec(stmt); err != nil {
 				if trans, ok := executor.(*gorp.Transaction); ok {
@@ -501,6 +506,7 @@ func getMigrationDbMap(db *sql.DB, dialect string) (*gorp.DbMap, error) {
 		return nil, fmt.Errorf("Unknown dialect: %s", dialect)
 	}
 
+	// TODO: Change to Flyway compatible table name if compatibility selected
 	// When using the mysql driver, make sure that the parseTime option is
 	// configured, otherwise it won't map time columns to time.Time. See
 	// https://github.com/j-whitehouse/sql-migrate/issues/2

--- a/migrate_test.go
+++ b/migrate_test.go
@@ -174,6 +174,22 @@ func (s *SqliteMigrateSuite) TestFileMigrate(c *C) {
 	c.Assert(id, Equals, int64(1))
 }
 
+func (s *SqliteMigrateSuite) TestLoopFileMigrate(c *C) {
+	migrations := &FileMigrationSource{
+		Dir: "test-loop-migrations",
+	}
+
+	// Executes two migrations
+	n, err := Exec(s.Db, "sqlite3", migrations, Up)
+	c.Assert(err, IsNil)
+	c.Assert(n, Equals, 3)
+
+	// Has data
+	id, err := s.DbMap.SelectInt("SELECT count(*) FROM people WHERE first_name IS NOT NULL")
+	c.Assert(err, IsNil)
+	c.Assert(id, Equals, int64(3))
+}
+
 func (s *SqliteMigrateSuite) TestHttpFileSystemMigrate(c *C) {
 	migrations := &HttpFileSystemMigrationSource{
 		FileSystem: http.Dir("test-migrations"),

--- a/sqlparse/sqlparse.go
+++ b/sqlparse/sqlparse.go
@@ -15,7 +15,7 @@ const (
 	optionNoTransaction = "notransaction"
 )
 
-type migrationStatement struct {
+type MigrationStatement struct {
 	Statement   string
 	Loop        bool
 	Conditional string
@@ -23,8 +23,8 @@ type migrationStatement struct {
 
 type ParsedMigration struct {
 	// Statements need a simple "Statement" string, a "Loop" flag and a loop "Conditional" string
-	UpStatements   []migrationStatement
-	DownStatements []migrationStatement
+	UpStatements   []MigrationStatement
+	DownStatements []MigrationStatement
 
 	DisableTransactionUp   bool
 	DisableTransactionDown bool
@@ -128,7 +128,7 @@ func ParseMigration(r io.ReadSeeker) (*ParsedMigration, error) {
 		return nil, err
 	}
 
-	// new migrationStatement type requires both
+	// new MigrationStatement type requires both
 	var statementBuf bytes.Buffer
 	var conditionalBuf bytes.Buffer
 	scanner := bufio.NewScanner(r)
@@ -266,17 +266,17 @@ func ParseMigration(r io.ReadSeeker) (*ParsedMigration, error) {
 		/* Conditional statement block must exist as one-per-loop, and be a single query
 		That query must return 0 for finished and and int > 0 for not-finished
 		Loop is any SQL statements outside the conditional block (conditional can sit anywhere)
-		The Loop & Conditional need to be part of the same migrationStatement
+		The Loop & Conditional need to be part of the same MigrationStatement
 		*/
 		if (!ignoreSemicolons && (endsWithSemicolon(line) || isLineSeparator)) || statementEnded {
 			statementEnded = false
 			switch currentDirection {
 			case directionUp:
-				newStatement := migrationStatement{statementBuf.String(), isLoop, conditionalBuf.String()}
+				newStatement := MigrationStatement{statementBuf.String(), isLoop, conditionalBuf.String()}
 				p.UpStatements = append(p.UpStatements, newStatement)
 
 			case directionDown:
-				newStatement := migrationStatement{statementBuf.String(), isLoop, conditionalBuf.String()}
+				newStatement := MigrationStatement{statementBuf.String(), isLoop, conditionalBuf.String()}
 				p.DownStatements = append(p.DownStatements, newStatement)
 
 			default:

--- a/test-loop-migrations/1_initial.sql
+++ b/test-loop-migrations/1_initial.sql
@@ -1,0 +1,8 @@
+-- +migrate Up
+-- SQL in section 'Up' is executed when this migration is applied
+CREATE TABLE people (id int);
+
+
+-- +migrate Down
+-- SQL section 'Down' is executed when this migration is rolled back
+DROP TABLE people;

--- a/test-loop-migrations/2_record.sql
+++ b/test-loop-migrations/2_record.sql
@@ -1,0 +1,7 @@
+-- +migrate Up
+INSERT INTO people (id) VALUES (5), (6), (7);
+
+-- +migrate Down
+DELETE FROM people WHERE id=5;
+DELETE FROM people WHERE id=6;
+DELETE FROM people WHERE id=7;

--- a/test-loop-migrations/3_backfill.sql
+++ b/test-loop-migrations/3_backfill.sql
@@ -1,0 +1,11 @@
+-- +migrate Up
+ALTER TABLE people ADD COLUMN first_name text;
+-- +LoopBegin
+UPDATE people SET first_name = 'Jim Bob' WHERE first_name IS NULL;
+-- +ConditionalBegin
+SELECT COUNT(*) FROM people WHERE first_name IS NULL;
+-- +ConditionalEnd
+-- +LoopEnd
+
+-- +migrate Down
+ALTER TABLE people DROP COLUMN first_name;


### PR DESCRIPTION
These modifications add support for looping backfills of a database. Really, any time of escaping loop is supported. There is no current max upper bound.

This enables zero downtime migrations without the need to write a custom backfill script, service or running a manual backfill. Essentially, the process to follow is as such:
- Initial Application State: Application writes to old location
- Migration: New column / table / &c added
- Intermediate State: Application reads from old location & writes to both locations
- Migration: Backfill new data location
- Intermediate State: Application reads from new location & writes to both locations
- Final Application State: Application reads & writes solely to & from the new location
- Final Migration: Drop original/old data location